### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,7 @@ dynamic = ["dependencies"]
 [tool.setuptools]
 packages = ["tests"]
 
-license = { file = "LICENSE" }  
-repository = "https://github.com/ai-cfia/nachet-datastore"  
-
-keywords = ["Nachet","ailab"]
+# keywords = ["Nachet","ailab"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
When trying to import the packages, it fails du to the presence of the following properties under `tool.setuptools`:
- keyword
- licence
- repository